### PR TITLE
Adding the Solution for Queue topic - Reveal Cards In Increasing Order Leetcode -- 950

### DIFF
--- a/RevealCardsInIncreasingOrde_raj_mistry01.java
+++ b/RevealCardsInIncreasingOrde_raj_mistry01.java
@@ -1,0 +1,31 @@
+
+class Solution {
+
+    public int[] deckRevealedIncreasing(int[] deck) {
+
+        if (deck.length == 1) {
+            return deck;
+        }
+
+        Arrays.sort(deck);
+        int res[] = new int[deck.length];
+        int k = 1;
+        int c = 0;
+        res[0] = deck[0];
+
+        // insert the elements from the sorted array into every 2nd empty slot of result array
+        while (k < deck.length) {
+            for (int i = 1; i < deck.length; i++) {
+                if (res[i] == 0) {
+                    c++;
+                    if (c == 2) {
+                        res[i] = deck[k++];
+                        c = 0;
+                    }
+                }
+            }
+        }
+
+        return res;
+    }
+}


### PR DESCRIPTION
Approach

First, sort the deck since the final revealed sequence must be in increasing order.

Use an auxiliary result array and simulate the reveal process in reverse.

Place the smallest card at the first position.

Then, for each next card, scan through the result array and count empty slots. Insert the card into every second empty slot, resetting the counter after placement.

This simulates the “reveal top card, move next card to bottom” sequence.

Complexity

Sorting: O(N log N)

Placement simulation: O(N²) in the worst case

Overall: O(N²)